### PR TITLE
Update ~ Decrease android transition time

### DIFF
--- a/android/src/main/res/v33/anim-v33/rns_default_enter_in.xml
+++ b/android/src/main/res/v33/anim-v33/rns_default_enter_in.xml
@@ -11,7 +11,7 @@
         android:fillAfter="true"
         android:interpolator="@android:anim/linear_interpolator"
         android:startOffset="50"
-        android:duration="83" />
+        android:duration="150" />
 
     <translate
         android:fromXDelta="10%"
@@ -21,7 +21,7 @@
         android:fillAfter="true"
         android:startOffset="0"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
-        android:duration="450" />
+        android:duration="150" />
 
     <extend
         android:fromExtendLeft="10%"
@@ -34,5 +34,5 @@
         android:toExtendBottom="0"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 </set>

--- a/android/src/main/res/v33/anim-v33/rns_default_enter_out.xml
+++ b/android/src/main/res/v33/anim-v33/rns_default_enter_out.xml
@@ -11,7 +11,7 @@
         android:fillAfter="true"
         android:interpolator="@anim/rns_standard_accelerate_interpolator"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 
     <translate
         android:fromXDelta="0"
@@ -21,7 +21,7 @@
         android:fillAfter="true"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 
     <extend
         android:fromExtendLeft="0"
@@ -34,5 +34,5 @@
         android:toExtendBottom="0"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 </set>

--- a/android/src/main/res/v33/anim-v33/rns_default_exit_in.xml
+++ b/android/src/main/res/v33/anim-v33/rns_default_exit_in.xml
@@ -11,7 +11,7 @@
         android:fillAfter="true"
         android:interpolator="@android:interpolator/linear"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 
     <translate
         android:fromXDelta="-10%"
@@ -21,7 +21,7 @@
         android:fillAfter="true"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 
     <extend
         android:fromExtendLeft="0"
@@ -34,5 +34,5 @@
         android:toExtendBottom="0"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 </set>

--- a/android/src/main/res/v33/anim-v33/rns_default_exit_out.xml
+++ b/android/src/main/res/v33/anim-v33/rns_default_exit_out.xml
@@ -11,7 +11,7 @@
         android:fillAfter="true"
         android:interpolator="@android:interpolator/linear"
         android:startOffset="35"
-        android:duration="83" />
+        android:duration="150" />
 
     <translate
         android:fromXDelta="0"
@@ -21,7 +21,7 @@
         android:fillAfter="true"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 
     <extend
         android:fromExtendLeft="10%"
@@ -34,5 +34,5 @@
         android:toExtendBottom="0"
         android:interpolator="@android:interpolator/fast_out_extra_slow_in"
         android:startOffset="0"
-        android:duration="450" />
+        android:duration="150" />
 </set>


### PR DESCRIPTION
Changed animation duration from `450` to `150` ms for android sdk version 33, as React Navigation didn't have an option to pass duration as a prop
Reference:
https://github.com/react-navigation/react-navigation/discussions/10591#discussioncomment-2827647
